### PR TITLE
fix broken relative file pathes when called from outside of project dir

### DIFF
--- a/run_in_venv.sh
+++ b/run_in_venv.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 # go to directory of file
-cd "$(dirname "$0")"
+IDO_DIR="$(dirname "$0")"
+
 # activate venv
-source venv/bin/activate
+source "$IDO_DIR/venv/bin/activate"
 # run app
-python3 app.py "$@"
+python3 "$IDO_DIR/app.py" "$@"


### PR DESCRIPTION
when calling `run_in_venv.sh` from outside of the project root folder, the previous behavior breaks relative pathes.
This prevents the current work dir from being changed, which keeps relative pathes intact and also correctly uses the venv.