### PR TITLE
fix confusing pip for python

### DIFF
--- a/find_cmds.sh
+++ b/find_cmds.sh
@@ -22,7 +22,7 @@ if [ -z "$PIP_CMD" ]; then
 		PIP_CMD=pip3
 	else
 		if command -v pip &>/dev/null; then
-			PIP_CMD=python
+			PIP_CMD=pip
 		else
 			echo "Pip not found" >&2
 			exit 1


### PR DESCRIPTION
i made a opsie in find_cmds.sh, copy-pasting the python part for pip and didn't replace all occurrences of python with pip :-(