### PR TITLE
dont use PIP_CMD to call the pip module

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -19,4 +19,4 @@ else
 fi
 
 # install dependencies from pyproject.toml
-$PYTHON_CMD -m $PIP_CMD install "$IDO_DIR/"
+$PYTHON_CMD -m pip install "$IDO_DIR/"

--- a/find_cmds.sh
+++ b/find_cmds.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 export PYTHON_CMD
-export PIP_CMD
 
 if [ -z "$PYTHON_CMD" ]; then
 
@@ -11,20 +10,6 @@ if [ -z "$PYTHON_CMD" ]; then
 			PYTHON_CMD=python
 		else
 			echo "Python not found" >&2
-			exit 1
-		fi
-	fi
-fi
-
-if [ -z "$PIP_CMD" ]; then
-
-	if command -v pip3 &>/dev/null; then
-		PIP_CMD=pip3
-	else
-		if command -v pip &>/dev/null; then
-			PIP_CMD=pip
-		else
-			echo "Pip not found" >&2
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
This addresses #35 .
I introduced a bug in a previous PR by finding out what is the actual pip command and using the command's mane as the pip-module, whats just wrong.
