### PR TITLE
Add fully automated GUI setup for Windows. One script to set up project and create GUI shortcut.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+.\windows_scripts\setup_and_make_launcher.ps1

--- a/gui.ps1
+++ b/gui.ps1
@@ -1,0 +1,4 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+.\venv\Scripts\Activate.ps1
+python3 gui.py
+pause  # This prevents the terminal from closing when Python closes. Its useful for reading errors without opening a new terminal, but it will leave the terminal open when the script is opened with a hidden window.

--- a/gui.py
+++ b/gui.py
@@ -478,7 +478,7 @@ class PixelPaintDialog(QDialog):
 
     def run_command(self, command_array):
         process = QProcess(self)
-        process.start("cmd.exe", ["/c", "py", "app.py"] + command_array)
+        process.start("cmd.exe", ["/c", "python3", "app.py"] + command_array)
         process.waitForFinished()
 
     def clear_device(self):
@@ -671,7 +671,7 @@ class DevicePage(QWidget):
             self.process.setProcessChannelMode(QProcess.MergedChannels)
             self.process.readyRead.connect(self.handle_ready_read)
             self.process.finished.connect(self.process_finished)
-            self.process.start("cmd.exe", ["/c", "py", "app.py"] + args)
+            self.process.start("cmd.exe", ["/c", "python3", "app.py"] + args)
 
     def handle_ready_read(self):
         data = self.process.readAll()
@@ -1214,7 +1214,7 @@ class MainWindow(QWidget):
         self.process.setProcessChannelMode(QProcess.MergedChannels)
         self.process.readyRead.connect(self.handle_ready_read)
         self.process.finished.connect(self.process_finished)
-        self.process.start("cmd.exe", ["/c", "py app.py --scan"])
+        self.process.start("cmd.exe", ["/c", "python3 app.py --scan"])
 
     def handle_ready_read(self):
         data = self.process.readAll()

--- a/setup_and_make_launcher.ps1
+++ b/setup_and_make_launcher.ps1
@@ -1,0 +1,55 @@
+# Starts by making sure the app is set up
+echo "Setting up iDotMatrix..."
+echo "(If something goes wrong, try running the script with an administrator instance of Powershell)"
+
+$root = $PSScriptRoot
+echo "Launching from: $root"
+
+if (Test-Path -Path "$root\gui.py") {
+	echo "gui.py found, assuming the script has launched from the correct path."
+} else {
+	echo "`nERROR: gui.py not found!`nThis means that the script wasn't launched from the correct folder.`n"
+		echo "To work correctly, you need to launch this script from the root folder of the iDotMatrix git folder."
+		echo "To do this, open the folder this script is located in in Windws Explorer, right click the script, and press 'Run in powershell'.`n"
+		echo "If that doesn't work, either open a powershell window and cd to the folder, or open the iDotMatrix git folder in Windows Explorer, then shift-right-click inside in an empty spot in the folder window, and click 'Open in powershell'."
+    echo "With powershell open, write .\\setup_and_make_launcher.ps1 and press enter"
+    pause
+    exit
+}
+
+echo "This script will now open the VENV and install the required PIP dependencies."
+if (Test-Path -Path "$root\venv\Scripts\Activate.ps1") {
+    echo "Venv set up, opening it."
+} else {
+    echo "Venv not set up, creating it. Make sure you have python installed."
+    python3 -m venv venv
+}
+
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+.\venv\Scripts\Activate.ps1
+echo "Making sure PIP requirements are met, installs them if not."
+python3 -m pip install ./
+python3 -m pip install pyqt5
+python3 -m pip install requests
+
+
+echo "`nThis script will now create the shortcut on your desktop."
+
+$WshShell = New-Object -COMObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut("$Home\Desktop\iDotMatrix GUI.lnk")
+$Shortcut.TargetPath = "%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe"
+
+$userInput = Read-Host -Prompt "`nDo you want the terminal to be hidden when launching the GUI?`n> [y/n]"
+if ($userInput -eq "y") {
+	$Shortcut.Arguments = "-WindowStyle Hidden -File `"$root\gui.ps1`""
+	echo "If the GUI isn't opening, re-run this script without hiding the terminal, so you can see what went wrong."
+} else {
+	$Shortcut.Arguments = "-File `"$root\gui.ps1`"" 
+}
+
+$Shortcut.IconLocation = "$root\idmc.ico"
+$Shortcut.WorkingDirectory = split-path -parent $MyInvocation.MyCommand.Definition
+$Shortcut.Save()
+echo "`n--------`nA shortcut should now have been created on your desktop. `nIf some commands in the script fails, first re-run without a hidden terminal if you chose to hide it, then make sure you have Python installed, and see if you can open the GUI manually through powershell, by manually using the commands in this file."
+echo "(If something went wrong, try running the script with an administrator instance of Powershell)"
+pause

--- a/windows_scripts/gui.ps1
+++ b/windows_scripts/gui.ps1
@@ -1,0 +1,10 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+$root = "$PSScriptRoot\.."
+. "$root\venv\Scripts\Activate.ps1"
+if (-not $?){
+	Write-Host "ERROR: Failed to open venv, try running the setup script in the /windows_scripts/ of the git folder."
+	exit
+}
+cd $root  # Python needs to open in the root of the git folder for relative paths to be correct.
+python3 ".\gui.py"
+pause

--- a/windows_scripts/resize_and_combine_all.ps1
+++ b/windows_scripts/resize_and_combine_all.ps1
@@ -1,0 +1,127 @@
+# Image resizer, gif-ifier, and merger.
+#
+# Requirements:
+#	Requires ImageMagick to be installed and on your path.
+#	How to install:
+#	- Get https://scoop.sh/
+#	- Run `scoop install imagemagick`
+#
+# Usage:
+# 	The script prompts you for inputs when you run it.
+# 	If you want to use the functions in your own scripts you can copy their lines directly.
+#
+# Other platforms (linux):
+#	This is a powershell script, but the imagemagick commands it will work on any platform with ImageMagick installed.
+#	Find the `magick` commands in the functions below, and copy them into your terminal, replacing the variables with your own values directly.
+#
+# What this does:
+# 	This script will convert every jpg+png+webp image in the input-folder to a gif of given pixel-size. 
+#	It then combines every gif in the output-folder into a single gif.
+#
+# 	If you want to merge your own gifs without converting anything, 
+#	you can put your gifs directly into the output folder of this script, so the script combines them. 
+#	If the folder doesn't exist you can run this script or make it manually. 
+#
+#	You don't need to put any images in your input folder for this.
+
+$outFolderName = "out"
+$outGifName = "_combined"
+
+
+Function MassForceResize {
+	param (
+		[string]$InDirPath,
+		[string]$OutDirPath,
+		[string]$InFiletype,
+		[string]$OutFiletype,
+		[int]$PixelSize
+	  )
+	if (-not (Test-Path $OutDirPath)) {
+	  New-Item -Path $OutDirPath -ItemType Directory
+	}
+	Get-ChildItem "$InDirPath\" -Filter "*.$InFiletype" | 
+	Foreach-Object {
+	$base = $_.BaseName
+	$out  = "$OutDirPath\$base.$OutFiletype"
+
+	#____ The ImageMagick command ____#
+	#| If you're not on Windows, you can copy this line and input your own values, and it'll work on any platform that can use ImageMagick.
+	magick $_.FullName -resize "${PixelSize}x${PixelSize}^" -gravity center -extent "${PixelSize}x${PixelSize}" $out
+
+	Write-Output "Created file: $out"
+	}
+}
+
+
+
+Function MergeGifs {
+	param (
+	[string]$InDirPath,
+	[string]$OutFileName,
+	[float]$DelayInSeconds
+	)
+	$DelayInCentiSeconds = $DelayInSeconds*100
+	$inp = "$InDirPath\*.gif" 
+	$out = "$InDirPath\$OutFileName.gif"
+	if (Test-Path $out) {
+		Remove-Item $out
+	}
+
+	#____ The ImageMagick command ____#
+	#| If you're not on Windows, you can copy this line and input your own values, and it'll work on any platform that can use ImageMagick.
+	magick -delay $DelayInCentiSeconds $inp $out
+
+	Write-Output "Created file: $out"
+}
+
+
+
+
+$inPath = ""
+$answer = Read-Host "Enter path of folder to convert ('.' for current path)"
+if ($answer -eq '.') {
+	$inPath = $PSScriptRoot
+} else {
+	$inPath = $answer
+}
+$outPath = "$inPath\$outFolderName"
+Write-Host "Using input-folder path:  $inPath"
+Write-Host "Using output-folder path: $outPath"
+
+Write-Host "`n## INFORMATION ##"
+Write-Host "`n### What this does ###"
+Write-Host "This script will convert every jpg+png+webp image in the input-folder to a gif of given pixel-size. It then combines every gif in the output-folder `"$outFolderName`", into a single gif named `"$outGifName`"."
+Write-Host "`n### How to combine your own gifs ###"
+Write-Host "If you only want to merge gifs, you can put your gifs directly into the output folder of this script, so the script combines them. If the folder doesn't exist you can run this script or make it manually. You also don't need to put images in your input folder."
+
+
+Write-Host "`n## IMAGE CONVERTING ##"
+$targetsize = 0.0
+do {
+	$inp = Read-Host "Enter pixel size to make output gifs (e.g. 32 or 16)"
+	$inputValid = [int]::TryParse($inp, [ref]$targetsize)
+	if (-not $inputValid) {
+		Write-Host "Input wasn't an integer, try again: "
+	}
+} while (-not $inputValid)
+
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "jpg"  -OutFiletype "gif" -PixelSize $targetsize
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "png"  -OutFiletype "gif" -PixelSize $targetsize
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "webp" -OutFiletype "gif" -PixelSize $targetsize
+
+
+Write-Host "`n## IMAGE LOOPING ##"
+$secondsBetweenGifs = 0.0
+do {
+	$inp = Read-Host "Enter number of seconds delay between each image, use commas for floats"
+	$inputValid = [float]::TryParse($inp, [ref]$secondsBetweenGifs)
+	if (-not $inputValid) {
+		Write-Host "Input wasn't float, try again. You need to use commas for floats, e.g. '3,5'"
+	}
+} while (-not $inputValid)
+
+
+MergeGifs -InDirPath "$outPath" -OutFileName "_combined" -DelayInSeconds $secondsBetweenGifs
+
+
+Write-Host "Script complete"

--- a/windows_scripts/setup_and_make_launcher.ps1
+++ b/windows_scripts/setup_and_make_launcher.ps1
@@ -1,0 +1,59 @@
+# Starts by making sure the app is set up
+Write-Host "Setting up iDotMatrix..."
+Write-Host "(If something goes wrong, try running the script with an administrator instance of Powershell)"
+
+$root = "$PSScriptRoot\.."
+Write-Host "Launching from: $root"
+
+if (Test-Path -Path "$root\gui.py") {
+	Write-Host "gui.py found, assuming the script has launched from the correct path."
+} else {
+	Write-Host "`nERROR: gui.py not found!`nThis means that the script wasn't launched from the correct folder.`n"
+		Write-Host "To work correctly, you need to launch this script from the root folder of the iDotMatrix git folder."
+		Write-Host "To do this, open the folder this script is located in in Windws Explorer, right click the script, and press 'Run in powershell'.`n"
+		Write-Host "If that doesn't work, either open a powershell window and cd to the folder, or open the iDotMatrix git folder in Windows Explorer, then shift-right-click inside in an empty spot in the folder window, and click 'Open in powershell'."
+    Write-Host "With powershell open, write .\windows_scripts\setup_and_make_launcher.ps1 and press enter"
+    pause
+    exit
+}
+
+Write-Host "This script will now open the VENV and install the required PIP dependencies."
+if (Test-Path -Path "$root\venv\Scripts\Activate.ps1") {
+    Write-Host "Venv set up, opening it."
+} else {
+    Write-Host "Venv not set up, creating it. Make sure you have python installed."
+    python3 -m venv venv
+}
+
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+. "$root\venv\Scripts\Activate.ps1"
+if (-not $?){
+	Write-Host "ERROR: Failed to open venv, exiting program. Make sure Python is installed."
+	exit
+}
+Write-Host "Making sure PIP requirements are met, installs them if not."
+python3 -m pip install ./
+python3 -m pip install pyqt5
+python3 -m pip install requests
+
+
+Write-Host "`nThis script will now create the shortcut on your desktop."
+
+$WshShell = New-Object -COMObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut("$Home\Desktop\iDotMatrix GUI.lnk")
+$Shortcut.TargetPath = "%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe"
+
+$userInput = Read-Host -Prompt "`nDo you want the terminal to be hidden when launching the GUI?`n> [y/n]"
+if ($userInput -eq "y") {
+	$Shortcut.Arguments = "-WindowStyle Hidden -File `"$root\windows_scripts\gui.ps1`""
+	Write-Host "If the GUI isn't opening, re-run this script without hiding the terminal, so you can see what went wrong."
+} else {
+	$Shortcut.Arguments = "-File `"$root\windows_scripts\gui.ps1`""  #-WindowStyle Hidden 
+}
+
+$Shortcut.IconLocation = "$root\idmc.ico"
+$Shortcut.WorkingDirectory = split-path -parent $MyInvocation.MyCommand.Definition
+$Shortcut.Save()
+Write-Host "`n--------`nA shortcut should now have been created on your desktop. `nIf some commands in the script fails, first re-run without a hidden terminal if you chose to hide it, then make sure you have Python installed, and see if you can open the GUI manually through powershell, by manually using the commands in this file."
+Write-Host "(If something went wrong, try running the script with an administrator instance of Powershell)"
+pause


### PR DESCRIPTION
The existing GUI build script wasn't working for me, due to a PyInstaller bug that requires a downgrade to fix. Downgrading PyInstaller is a bit much to ask non-tech-savvy users, so I realized I could use a powershell workaround to not require it.

This script first sets up the project if it isn't already set up, and then it creates a shortcut which opens the GUI through a (optionally hidden) powershell window, instead of PyInstaller.