### PR TITLE
(no squash) Add reset cmd, add weather to CLI, add unprocessed buttons to GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+venv_windows/
 ENV/
 env.bak/
 venv.bak/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@
   * [Prerequisites](#prerequisites)
   * [Installation](#installation)
 * [Usage](#usage)
+* [Gif Compilations](#gif-compilations)
 * [GUI](#gui)
+* [Troubleshooting](#troubleshooting)
 * [Roadmap](#roadmap)
 * [Contributing](#contributing)
 * [License](#license)
@@ -61,10 +63,31 @@ To get a local copy up and running follow these simple example steps:
 
 Please install the following for your OS:
 
-* latest Python3
-* Python3 Virtual Env
+* Latest version of Python (Python3)
 
-windows users, to use the `.sh` scripts below you will need to use msys/gitbash, or roll your own
+
+#### For windows
+
+The `build.ps1` script automatically handles setting up the python virtual environment and a shortcut to the GUI. Powershell scripts can be opened by right clicking them and clicking "Run with PowerShell", or by nagivating to them in a PowerShell terminal and writing their filename as a command.
+
+If you want to use the `.sh` scripts included in this repo on in Windows, you will need `msys2` or `git bash`.
+The Python CLI program can be used without the `.sh` scripts in plain powershell/cmd, by manually opening the VENV like so:
+
+```ps1
+git clone https://github.com/derkalle4/python3-idotmatrix-client.git
+cd python3-idotmatrix-client
+pwd 				# Make sure that this is the path to your copy of this repository. 
+				# If its not, navigate to it with cd, or shift-right-click the folder and click "open in powershell".
+python3 -m venv venv  		# Creates the venv, not necessary if you've used the build.ps1 script.
+.\venv\Scripts\Activate.ps1  	# Opens the venv. Omit ".ps1" if you're using cmd.
+python3 -m pip install .\	# Downloads requirements from pyproject.toml
+python3 -m pip install pyqt5	# Only necessary for the GUI
+python3 .\app.py -h		# Replace -h with your commandline arguments
+```
+
+
+
+
 
 ### Installation
 
@@ -74,11 +97,29 @@ windows users, to use the `.sh` scripts below you will need to use msys/gitbash,
 git clone https://github.com/derkalle4/python3-idotmatrix-client.git
 ```
 
-2. Create virtual environment and install all dependencies
+2. `cd` to it
 
+```sh
+cd python3-idotmatrix-client
+```
+
+3. Create virtual environment and install all dependencies
+    
 ```sh
 ./create_venv.sh
 ```
+
+* This can alternatively be done with the automated venv & GUI setup script for Windows Powershell
+
+```ps1
+.\build.ps1
+# This script automatically sets up the virtual environment and a shortcut to the GUI.
+# You can alternately open it by right clicking the file in Windows Explorer and choosing "Run with powershell".
+```
+
+
+
+
 
 ## Usage
 
@@ -87,7 +128,8 @@ If you used the ./create_venv.sh you should use this command to run the app:
 ```sh
 ./run_in_venv.sh <YOUR_COMMAND_LINE_ARGUMENTS>
 ```
-If you do not use a virtual environment the command will look like this:
+
+If you have manually opened the virtual environment, or are not using a virtual environment, the same can be accomplished with the following:
 
 ```sh
 python3 .\app.py <YOUR_COMMAND_LINE_ARGUMENTS>
@@ -361,7 +403,23 @@ Sets the background color of the text.
 ./run_in_venv.sh --address 00:11:22:33:44:ff --set-text "Hello World" --text-bg-color 0-0-255
 ```
 
+### Gif Compilations
+
+There's no internal method for creating a compilation of gifs or images, similar to what the app offers, 
+but you can create this manually with external tools like https://ezgifs.com/, and upload it to the iDotMatrix device as a single gif.
+
+There's also an internal helper script for Windows to convert and compile all images and videos in a folder: `/windows_scripts/resize_and_compile_all.ps1`.
+
+The above script is for Powershell, but at its core it just uses two small ImageMagick commands, which you can look at and use on any plataform.
+
+After compiling a GIF, you can upload it with the GUI, or with a command:
+```sh
+./run_in_venv.sh --address auto --set-gif /path/to/your/gif.gif
+```
+
+
 ## GUI
+
 ### Run Methods
 You can run the GUI uncompiled with python, or you can build an executible with Pyinstaller.
 
@@ -370,9 +428,13 @@ You can run the GUI uncompiled with python, or you can build an executible with 
 * Run ```pip install pyqt5```
 * Run ```py gui.py```
 
-#### Method 2) Build and Run
+#### Method 2) Build and Run using PyInstaller
 * Run ```build.bat``` for **Windows** or ```build.sh``` for **Linux**
 * Click the new ```iDotMatrix Controller``` program in ```/python3-idotmatrix-client```
+
+#### Method 3) Build and Run using Windows Powershell
+* Open ```build.ps1``` and follow instructions
+* Click the new ```iDotMatrix GUI``` program on your desktop
 
 ### Features
 * **Device Search**: *Scans for nearby devices, asks for name, adds to home screen.*
@@ -395,6 +457,21 @@ You can run the GUI uncompiled with python, or you can build an executible with 
 *Found a GUI bug? Submitting a new GUI request? Tag [@TheBigWazz](https://github.com/thebigwazz)*
 
 </br>
+
+## Troubleshooting
+
+### Can't find device ID 
+
+Make sure that bluetooth is on, and that the iDotMatrix display is on and within range.
+
+One thing that can cause this issue is an instance of Python running the script in the background, especially for the GUI.
+After quitting open instances of this program, open up the task manager for your platform, and see if you can find and kill a task starting with "Python", before trying to use this program again.
+
+If that doesn't work, try restarting your computer and disconnect/reconnect the iDotMatrix display from power.
+
+If all else fails, open an issue in GitHub.
+
+
 
 ## Roadmap
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+.\windows_scripts\setup_and_make_launcher.ps1

--- a/core/cmd.py
+++ b/core/cmd.py
@@ -230,6 +230,11 @@ class CMD:
             help="sets the text background color. Format: <R0-255>-<G0-255>-<B0-255> (example: 255-255-255)",
             default="255-255-255",
         )
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Sends the reset command to the display. This can sometimes help fix persistent glitches.",
+        )
 
     async def run(self, args):
         self.logging.info("initializing command line")
@@ -263,6 +268,8 @@ class CMD:
             await self.set_brightness(int(args.set_brightness))
         if args.set_password:
             await self.set_password(args.set_password)
+        if args.reset:
+            await self.reset(args)
         # arguments which cannot run in parallel
         if args.test:
             await self.test()
@@ -568,3 +575,13 @@ class CMD:
             text_bg_mode=args.text_bg_mode,
             text_bg_color=(int(bg_color[0]), int(bg_color[1]), int(bg_color[2])),
         )
+
+    async def reset(self, args):
+        # The following was figured out by 8none1:
+        # https://github.com/8none1/idotmatrix/commit/1a08e1e9b82d78427ab1c896c24c2a7fb45bc2f0
+        reset_packets = [
+            bytes(bytearray.fromhex("04 00 03 80")),
+            bytes(bytearray.fromhex("05 00 04 80 50")),
+            ]
+        for packet in reset_packets:
+            await self.conn.send(packet)

--- a/core/cmd.py
+++ b/core/cmd.py
@@ -4,6 +4,7 @@ import logging
 import os
 from PIL import Image
 import time
+from utils import utils
 
 # idotmatrix imports
 from idotmatrix import ConnectionManager
@@ -235,6 +236,24 @@ class CMD:
             action="store_true",
             help="Sends the reset command to the display. This can sometimes help fix persistent glitches.",
         )
+        parser.add_argument(
+            "--weather-api-key",
+            action="store",
+            type=str,
+            help="The 'https://weatherapi.com' api key for weather commands.",
+        )
+        parser.add_argument(
+            "--weather-image-query",
+            action="store",
+            type=str,
+            help="Query to send weatherapi, e.g. city name. Displays an image representing the current weather. \nThis arg requires you to also pass '--process-image' with your pixel size, and the '--weather-api-key' with your 'https://weatherapi.com/' API key.",
+        )
+        parser.add_argument(
+            "--weather-gif-query",
+            action="store",
+            type=str,
+            help="Query to send weatherapi, e.g. city name. Displays a gif representing current weather. \nThis arg requires you to also pass '--process-image' with your pixel size, and the '--weather-api-key' with your 'https://weatherapi.com/' API key.",
+        )
 
     async def run(self, args):
         self.logging.info("initializing command line")
@@ -291,6 +310,10 @@ class CMD:
             await self.gif(args)
         elif args.set_text:
             await self.text(args)
+        elif args.weather_image_query:
+            await self.weather_image_query(args)
+        elif args.weather_gif_query:
+            await self.weather_gif_query(args)
 
     async def test(self):
         """Tests all available options for the device"""
@@ -585,3 +608,25 @@ class CMD:
             ]
         for packet in reset_packets:
             await self.conn.send(packet)
+
+    async def weather_image_query(self, args):
+        api_key = args.weather_api_key
+        pixels  = args.process_image
+        try:
+            img_path = utils.get_weather_img(args.weather_image_query, pixels, api_key)
+        except Exception as e:
+            self.logging.error(f"failed to get weather info or make weather image: {e}")
+        else:
+            setattr(args, 'image', img_path)
+            self.image(args)
+
+    async def weather_gif_query(self, args):
+        api_key = args.weather_api_key
+        pixels  = args.process_image
+        try:
+            gif_path = utils.get_weather_gif(args.weather_gif_query, pixels, api_key)
+        except Exception as e:
+            self.logging.error(f"failed to get weather info or make weather gif: {e}")
+        else:
+            setattr(args, 'gif', gif_path)
+            self.gif(args)

--- a/gui.py
+++ b/gui.py
@@ -1,12 +1,11 @@
 import requests
 from datetime import datetime
 from PIL import Image, ImageDraw, ImageSequence
-import imageio
 import numpy
 
 
 
-from utils.utils import digits,patterns, colors, api_key
+from utils.utils import digits, patterns, colors
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QPushButton, QLabel, QStackedWidget,
     QPlainTextEdit, QHBoxLayout, QMessageBox, QListWidgetItem, QGridLayout,
@@ -16,6 +15,8 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QFont, QIcon, QColor
 from PyQt5.QtCore import Qt, QProcess, QSettings, pyqtSignal
 import sys, re, copy
+
+
 
 # --- Dialog Classes ---
 class ClockStyleDialog(QDialog):
@@ -97,6 +98,27 @@ class CustomInputDialog(QDialog):
             return self.line_edit.text(), True
         else:
             return '', False
+
+class SizeDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Choose Pixel Display Size")
+        layout = QVBoxLayout()
+        self.size_combo = QComboBox()
+        self.size_combo.addItems(["16x16", "32x32"])
+        layout.addWidget(self.size_combo)
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        button_box.accepted.connect(self.accept)
+        layout.addWidget(button_box)
+        self.setLayout(layout)
+
+    def get(self):
+        if self.exec_() == QDialog.Accepted:
+            return self.size_combo.currentText().split("x")[0], True
+        else:
+            return "16", False
+
+
 
 class TextStyleDialog(QDialog):
     def __init__(self, parent=None):
@@ -627,17 +649,18 @@ class DevicePage(QWidget):
             ("Clock Style", self.clock_control),
             ("Sync Time", self.sync_time),
             ("Set Time", self.set_time),
+            ("Set Text", self.set_text),
             ("Screen On", lambda: self.screen_control("on")),
             ("Screen Off", lambda: self.screen_control("off")),
             ("Stop Watch", self.chronograph_control),
             ("Countdown Timer", lambda: self.countdown_control(1)),
-            ("Set Text", self.set_text),
             ("Color Studio", self.color_control),
             ("Scoreboard", self.open_scoreboard),
             ("Set Image", self.set_image),
             ("Set GIF", self.set_gif),
             ("Set Raw Image", self.set_image_unprocessed),
             ("Set Raw GIF", self.set_gif_unprocessed),
+            ("Set Weather API-Key", self.set_weather_api_key),
             ("Set Weather", self.set_weather),
             ("Set Weather GIF", self.set_weather_gif),
 
@@ -759,211 +782,6 @@ class DevicePage(QWidget):
         time, ok_pressed = QInputDialog.getText(self, "Set Time", "Enter the time (DD-MM-YYYY-HH:MM:SS):")
         if ok_pressed:
             self.run_command(["--address", self.mac_address, "--set-time", time])
-    pass
-    def set_weather(self):
-        city, ok_pressed = QInputDialog.getText(self, "Set Weather", "Enter the city:")
-
-        if ok_pressed and city:  # Check if there is a city
-            def get_current_data(city):
-                url = f"https://api.weatherapi.com/v1/current.json?q={city}&key={api_key}"
-                response = requests.get(url)
-                data = response.json()
-                if response.status_code == 200:
-                    return data
-                else:
-                    raise ValueError("It could not get the info")
-
-            def draw_digit(draw, x_offset, y_offset, digit):
-                pattern = digits[digit]
-                for y, row in enumerate(pattern):
-                    for x, pixel in enumerate(row):
-                        if pixel == "1":
-                            draw.point((x + x_offset, y + y_offset), fill="white")
-
-            def draw_colored_pattern(draw, x_offset, y_offset, key):
-                if key not in patterns:
-                    raise ValueError(f"The pattern '{key}' is not defined.")
-                pattern = patterns[key]
-                for y, row in enumerate(pattern):
-                    for x, pixel in enumerate(row):
-                        if pixel in colors:
-                            draw.point((x + x_offset, y + y_offset), fill=colors[pixel])
-
-            def get_weather_category(condition_code,is_day):
-                weather_switch = {
-                    "sun": [1000],
-                    "partly cloudy": [1003],
-                    "cloudy": [1006, 1009],
-                    "fog": [1030, 1135, 1147],
-                    "raining": [
-                    1063, 1150, 1153, 1180, 1183, 1186, 1189, 1192, 1195, 1240,
-                    1243, 1246, 1273, 1276
-                    ],
-                    "snowing": [
-                    1066, 1114, 1117, 1168, 1171, 1204, 1207, 1210, 1213, 1216,
-                    1219, 1222, 1225, 1255, 1258, 1279, 1282
-                    ],
-                    "thundering": [1087, 1273, 1276, 1279, 1282],
-                    "windy": [1114, 1117]
-                }
-                if is_day == 0:
-                # If it is night , we change the category
-                    weather_switch["moon"] = weather_switch.pop("sun", [1000])
-                    weather_switch["partly cloudy night"] = weather_switch.pop("partly cloudy", [1003])
-
-               
-
-                for category, codes in weather_switch.items():
-                    if condition_code in codes:
-                        return category
-                return "unknown"
-
-        # OGet weather data
-            data_api = get_current_data(city)
-
-            current_weather_code = data_api["current"]["condition"]["code"]
-            is_day = data_api["current"]["is_day"]
-            
-            weather_category = get_weather_category(current_weather_code,is_day)
-            
-
-            temperature_celsius = int(round(data_api["current"]["temp_c"])) 
-            
-        # Do pixel img
-            img = Image.new('RGB', (16, 16), color='black')
-            draw = ImageDraw.Draw(img)
-
-        # Extract the celsius digits
-            first_digit = str(temperature_celsius).zfill(2)[0]
-            second_digit = str(temperature_celsius).zfill(2)[1]
-
-        # Draw temperature and weather
-            draw_digit(draw, 3, 8, first_digit)
-            draw_digit(draw, 9, 8, second_digit)
-            draw_colored_pattern(draw, 4, 0, weather_category)
-
-        # Save the img
-            file_path = "weather.png"
-            img.save(file_path)
-
-        # Run the command with the new img
-            self.run_command([
-            "--address", self.mac_address,
-            "--image", "true",
-            "--set-image", file_path,
-            "--process-image", str(16)
-        ])
-
-    pass
-    def set_weather_gif(self):
-        
-        city, ok_pressed = QInputDialog.getText(self, "Set Weather", "Enter the city:")
-
-        if ok_pressed and city:
-            def get_current_data(city):
-                #2 days, just in case the actual hour +6 is the next day
-                url = f"https://api.weatherapi.com/v1/forecast.json?q={city}&days=2&key={api_key}"
-                response = requests.get(url)
-                data = response.json()
-                if response.status_code == 200:
-                    return data
-                else:
-                    raise ValueError("It could not get the info")
-                
-            def draw_digit(draw, x_offset, y_offset, digit):
-                pattern = digits[digit]
-                for y, row in enumerate(pattern):
-                    for x, pixel in enumerate(row):
-                        if pixel == "1":
-                            draw.point((x + x_offset, y + y_offset), fill=(255,255,255))
-            def draw_colored_pattern(draw, x_offset, y_offset, key):
-                if key not in patterns:
-                    raise ValueError(f"The pattern '{key}' is not defined.")
-                pattern = patterns[key]
-                for y, row in enumerate(pattern):
-                    for x, pixel in enumerate(row):
-                        if pixel in colors:
-                            draw.point((x + x_offset, y + y_offset), fill=colors[pixel])
-            
-            def get_weather_category(condition_code,is_day):
-                weather_switch = {
-                    "sun": [1000],
-                    "partly cloudy": [1003],
-                    "cloudy": [1006, 1009],
-                    "fog": [1030, 1135, 1147],
-                    "raining": [
-                    1063, 1150, 1153, 1180, 1183, 1186, 1189, 1192, 1195, 1240,
-                    1243, 1246, 1273, 1276
-                    ],
-                    "snowing": [
-                    1066, 1114, 1117, 1168, 1171, 1204, 1207, 1210, 1213, 1216,
-                    1219, 1222, 1225, 1255, 1258, 1279, 1282
-                    ],
-                    "thundering": [1087, 1273, 1276, 1279, 1282],
-                    "windy": [1114, 1117]
-                }
-                if is_day == 0:
-                # If it is night , we change the category
-                    weather_switch["moon"] = weather_switch.pop("sun", [1000])
-                    weather_switch["partly cloudy night"] = weather_switch.pop("partly cloudy", [1003])
-
-                for category, codes in weather_switch.items():
-                    if condition_code in codes:
-                        return category
-                return "unknown"
-
-            data_api = get_current_data(city)
-            current_hour = int(data_api["location"]["localtime"].split()[1].split(":")[0])
-            
-            hourly_forecast = data_api["forecast"]["forecastday"][0]["hour"]
-            #Array for all the images
-            images=[]
-            #range must be max 6 because specs
-            for i in range(6):
-                #Checking if the next hour is in the same day or next
-                hour_index = (current_hour + i) % 24
-                if current_hour + i < 24:  # Same day
-                    hour_data = data_api["forecast"]["forecastday"][0]["hour"][hour_index]
-                else:  # Next day
-                    hour_data = data_api["forecast"]["forecastday"][1]["hour"][hour_index]
-
-                condition_code = hour_data["condition"]["code"]
-                is_day = hour_data["is_day"]
-                
-                #Celsius temperature
-                temperature_celsius = int(round(hour_data["temp_c"]))
-
-                weather_category = get_weather_category(condition_code, is_day)
-                
-                # Create the pixel image
-                img = Image.new('RGB', (16, 16), color=1)
-                draw = ImageDraw.Draw(img)
-
-                # Extract the Celsius digits
-                first_digit = str(temperature_celsius).zfill(2)[0]
-                second_digit = str(temperature_celsius).zfill(2)[1]
-                # Determine the digit color (red for the first image, white for others)
-                
-                draw.rectangle([0, 15, i, 15], fill=(255, 255, 255))  #horizontal line to draw the hour, each point is the index of the hour
-
-                draw_digit(draw, 3, 8, first_digit)
-                draw_digit(draw, 9, 8, second_digit)
-                draw_colored_pattern(draw, 4, 0, weather_category)
-                
-                # Save the gif with a unique name
-                if img.getbbox():
-                    images.append(img)
-                else:
-                    print(f"IMG {i} is empty, it will not be added")
-
-            # Run the command with the new image
-            
-            images_array = [numpy.array(img) for img in images]
-
-            gif_path = "weather_forecast.gif"
-
-            images[0].save(gif_path, save_all=True, append_images=images[1:], duration=[1000, 1000, 1000, 1000, 1000, 1000], loop=0)
-            self.run_command(["--address", self.mac_address, "--set-gif", gif_path, "--process-gif", str(16)])
 
 
     def screen_control(self, state):
@@ -994,6 +812,7 @@ class DevicePage(QWidget):
         else:
             print("Countdown canceled, no command will be executed.")
 
+	
     def set_text(self):
         dialog = TextStyleDialog(self)
         settings = dialog.get_settings()
@@ -1097,6 +916,38 @@ class DevicePage(QWidget):
 
         if file_path:
             self.run_command(["--address", self.mac_address, "--set-gif", file_path])
+
+    def set_weather_api_key(self):
+        response, responded = QInputDialog.getText(self, "API Key", "Enter your 'https://weatherapi.com' api key")
+        if responded:
+            self.weatherapi_api_key = response
+        else:
+            print("No api key was provided, this is needed for the weather functionality.")
+
+    def set_weather(self):
+        city, ok_pressed = QInputDialog.getText(self, "Set Weather", "Remember to set the API key first. \nEnter the city query, e.g. name:")
+        size, ignore     = SizeDialog().get()
+
+        if ok_pressed and city:
+            self.run_command([
+                "--address", self.mac_address,
+                "--process-image", str(size),
+                "--weather-api-key", self.weatherapi_api_key,
+                "--weather-image-query", city,
+            ])
+
+    def set_weather_gif(self):
+        city, ok_pressed = QInputDialog.getText(self, "Set Weather", "Remember to set the API key first. \nEnter the city query, e.g. name:")
+        size, ignore     = SizeDialog().get()
+
+        if ok_pressed and city:
+            self.run_command([
+                "--address", self.mac_address,
+                "--process-image", str(size),
+                "--weather-api-key", self.weatherapi_api_key,
+                "--weather-gif-query", city,
+            ])
+
     def reset(self):
         self.run_command([
             "--address", self.mac_address,

--- a/gui.py
+++ b/gui.py
@@ -478,7 +478,7 @@ class PixelPaintDialog(QDialog):
 
     def run_command(self, command_array):
         process = QProcess(self)
-        process.start("cmd.exe", ["/c", "py", "app.py"] + command_array)
+        process.start("cmd.exe", ["/c", "python", "app.py"] + command_array)
         process.waitForFinished()
 
     def clear_device(self):
@@ -671,7 +671,7 @@ class DevicePage(QWidget):
             self.process.setProcessChannelMode(QProcess.MergedChannels)
             self.process.readyRead.connect(self.handle_ready_read)
             self.process.finished.connect(self.process_finished)
-            self.process.start("cmd.exe", ["/c", "py", "app.py"] + args)
+            self.process.start("cmd.exe", ["/c", "python", "app.py"] + args)
 
     def handle_ready_read(self):
         data = self.process.readAll()
@@ -1214,7 +1214,7 @@ class MainWindow(QWidget):
         self.process.setProcessChannelMode(QProcess.MergedChannels)
         self.process.readyRead.connect(self.handle_ready_read)
         self.process.finished.connect(self.process_finished)
-        self.process.start("cmd.exe", ["/c", "py app.py --scan"])
+        self.process.start("cmd.exe", ["/c", "python app.py --scan"])
 
     def handle_ready_read(self):
         data = self.process.readAll()

--- a/gui.py
+++ b/gui.py
@@ -636,6 +636,8 @@ class DevicePage(QWidget):
             ("Scoreboard", self.open_scoreboard),
             ("Set Image", self.set_image),
             ("Set GIF", self.set_gif),
+            ("Set Raw Image", self.set_image_unprocessed),
+            ("Set Raw GIF", self.set_gif_unprocessed),
             ("Set Weather", self.set_weather),
             ("Set Weather GIF", self.set_weather_gif),
 
@@ -1052,8 +1054,17 @@ class DevicePage(QWidget):
                 image_size = size_combo.currentText().split("x")[0]
                 self.run_command(["--address", self.mac_address, "--image", "true", "--set-image", file_path, "--process-image", image_size])
 
+    def set_image_unprocessed(self):
+        options = QFileDialog.Options()
+        options |= QFileDialog.ReadOnly
+        file_path, _ = QFileDialog.getOpenFileName(self, "Select Image", "", "PNG Files (*.png);;All Files (*)", options=options)
+
+        if file_path:
+            self.run_command(["--address", self.mac_address, "--image", "true", "--set-image", file_path])
+
+
     def set_gif(self):
-        confirmation = QMessageBox.question(self, "GIF Notice", "All GIFs are processed by default to ensure maximum compatibility. \n\nThis doesn't always work for all GIFs. \n\nGIFs closer to 32x32 or 16x16 have better chances of working.",
+        confirmation = QMessageBox.question(self, "GIF Notice", "All GIFs are processed by default to ensure maximum compatibility. If you get errors try setting with the other button. \n\nThis doesn't always work for all GIFs. \n\nGIFs closer to 32x32 or 16x16 have better chances of working.",
                                             QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
         if confirmation == QMessageBox.Yes:
@@ -1078,6 +1089,14 @@ class DevicePage(QWidget):
                     image_size = size_combo.currentText().split("x")[0]
                     self.run_command(["--address", self.mac_address, "--set-gif", file_path, "--process-gif", image_size])
 
+
+    def set_gif_unprocessed(self):
+        options = QFileDialog.Options()
+        options |= QFileDialog.ReadOnly
+        file_path, _ = QFileDialog.getOpenFileName(self, "Select GIF", "", "GIF Files (*.gif);;All Files (*)", options=options)
+
+        if file_path:
+            self.run_command(["--address", self.mac_address, "--set-gif", file_path])
     def reset(self):
         self.run_command([
             "--address", self.mac_address,

--- a/gui.py
+++ b/gui.py
@@ -656,6 +656,8 @@ class DevicePage(QWidget):
             ("Countdown Timer", lambda: self.countdown_control(1)),
             ("Color Studio", self.color_control),
             ("Scoreboard", self.open_scoreboard),
+            ("Set Raw Image", self.set_image_unprocessed),
+            ("Set Raw GIF", self.set_gif_unprocessed),
             ("Set Image", self.set_image),
             ("Set GIF", self.set_gif),
             ("Set Raw Image", self.set_image_unprocessed),

--- a/gui.py
+++ b/gui.py
@@ -623,6 +623,7 @@ class DevicePage(QWidget):
         grid_layout = QGridLayout()
         self.action_buttons = []
         actions = [
+            ("Reset", self.reset),
             ("Clock Style", self.clock_control),
             ("Sync Time", self.sync_time),
             ("Set Time", self.set_time),
@@ -1076,6 +1077,15 @@ class DevicePage(QWidget):
                 if size_dialog.exec_() == QDialog.Accepted:
                     image_size = size_combo.currentText().split("x")[0]
                     self.run_command(["--address", self.mac_address, "--set-gif", file_path, "--process-gif", image_size])
+
+    def reset(self):
+        self.run_command([
+            "--address", self.mac_address,
+            "--reset",
+        ])
+        
+
+
 
 class ConfigurationPage(QWidget):
     def __init__(self, main_window):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
   "idotmatrix==0.0.8",
   "bleak",
   "pillow",
-  "argparse"
+  "argparse",
+  "numpy",
+  "requests"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 ]
 dependencies = [
   "asyncio",
-  "idotmatrix==0.0.7",
+  "idotmatrix==0.0.8",
   "bleak",
   "pillow",
   "argparse"

--- a/run_in_venv.ps1
+++ b/run_in_venv.ps1
@@ -1,0 +1,68 @@
+param(
+    [switch]$DontInvokeApp  # Used to pass args directly to python, not app.py, e.g. for installing non-standard pip packages.
+    )
+
+$originalArgs = $args
+$originalPath = Get-Location
+& {
+    $root = $PSScriptRoot
+    Set-Location -Path "$root"
+
+    $likelyCorrectPath = Test-Path -Path "$root\app.py" -PathType Leaf
+    if (-not $likelyCorrectPath){
+        Write-Host "ERROR: The script seems to have been run from the wrong path. Try right-clicking the .ps1 file and clicking 'run with powershell'."
+        Set-Location -Path $originalPath
+        pause
+        exit
+    }
+
+
+    $venvAlreadyExists = Test-Path -Path "$root\venv_windows\Scripts\Activate.ps1" -PathType Leaf
+    if (-not $venvAlreadyExists) {
+        Write-Host "Venv for Windows doesn't exist, creating it. "
+        python -m venv "$root\venv_windows"
+        if (-not $?){
+            Write-Host "`nERROR: Failed to create venv, exiting program. Make sure Python is installed."
+            Set-Location -Path $originalPath
+            pause
+            exit
+        }
+        Write-Host "Venv created."
+    }
+
+
+    Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+    . "$root\venv_windows\Scripts\Activate.ps1"
+    if (-not "$?"){
+        Write-Host "ERROR: Failed to open venv. Make sure Python is installed, then try this script again."
+        Set-Location -Path $originalPath
+        pause
+        exit
+    }
+
+    $py_cmd = "python"
+    if (Test-Path -Path "$root/venv_windows/Scripts/python3.exe" -PathType Leaf ){
+        $py_cmd = "$root/venv_windows/Scripts/python3.exe"
+    } elseif (Test-Path -Path "$root/venv_windows/Scripts/python.exe" -PathType Leaf){
+        $py_cmd = "$root/venv_windows/Scripts/python.exe"
+    } else {
+        Write-Host "ERROR: Failed to find venv's python executable, try re-making the venv by deleting the 'venv_windows' folder and running build.ps1."
+        Set-Location -Path $originalPath
+        pause
+        exit
+    }
+
+    if (-not $venvAlreadyExists){
+        Write-Host "Istalling dependencies into venv."
+        & $py_cmd -m pip install "$root/"
+    }
+
+    if ($DontInvokeApp){
+        & $py_cmd $originalArgs
+    } else {
+        & $py_cmd "$root/app.py" $originalArgs
+    }
+
+    Set-Location -Path $originalPath
+
+}

--- a/run_in_venv.sh
+++ b/run_in_venv.sh
@@ -2,16 +2,22 @@
 set -e
 # get directory of file
 IDO_DIR="$(dirname "$0")"
-# activate venv
+
+# ensure we have the right global python
+. "$IDO_DIR"/find_cmds.sh
+
+# enable venv
+# Check if the OS is Windows and choose the correct activation script
 if [[ "$OSTYPE" == "msys" ]]; then
     # Windows Git Bash
     source "$IDO_DIR/venv/Scripts/activate"
+    PYTHON_CMD_VENV="$IDO_DIR/venv/Scripts/$PYTHON_CMD"
 else
     # POSIX (Linux, macOS, etc.)
     source "$IDO_DIR/venv/bin/activate"
+    PYTHON_CMD_VENV="$IDO_DIR/venv/bin/$PYTHON_CMD"
 fi
-
-. "$IDO_DIR"/find_cmds.sh
+# todo: Check for binaries similar to find_cmds. A venv can be created with python3 but only contain pytgom on some systems
 
 # run app
-$PYTHON_CMD "$IDO_DIR/app.py" "$@"
+$PYTHON_CMD_VENV "$IDO_DIR/app.py" "$@"

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,3 +1,7 @@
+import requests
+from PIL import Image, ImageDraw
+import numpy
+
 digits = {
     "-": [
         "    ",
@@ -112,6 +116,8 @@ colors = {
     "bl":"#0088ff", #blue
     
 }
+
+
 patterns = {
     "sun": [
         ["b", "b", "b", "b", "b", "b", "b", "b"],
@@ -215,7 +221,155 @@ patterns = {
     ],
 }
 
-#You need to create a free account in www.weatherapi.com , completely free , no credit card needed
-#Copy and paste your api key betweent the ""
-#example : "4bda1f92e2d64d3b9352567947a8900"
-api_key = ""
+
+def draw_digit(draw, x_offset, y_offset, digit):
+    pattern = digits[digit]
+    for y, row in enumerate(pattern):
+        for x, pixel in enumerate(row):
+            if pixel == "1":
+                draw.point((x + x_offset, y + y_offset), fill=(255,255,255))
+
+def draw_colored_pattern(draw, x_offset, y_offset, key):
+    if key not in patterns:
+        raise ValueError(f"The pattern '{key}' is not defined.")
+    pattern = patterns[key]
+    for y, row in enumerate(pattern):
+        for x, pixel in enumerate(row):
+            if pixel in colors:
+                draw.point((x + x_offset, y + y_offset), fill=colors[pixel])
+
+
+def get_current_weather_data(city_query, api_key):
+    url = f"https://api.weatherapi.com/v1/current.json?q={city_query}&key={api_key}"
+    response = requests.get(url)
+    data = response.json()
+    if response.status_code == 200:
+        return data
+    else:
+        raise ValueError("API could not get info on given city query, or invalid API key.")
+
+
+def get_current_weather_data_forecast(city_query, api_key):  
+    #2 days, just in case the actual hour +6 is the next day
+    url = f"https://api.weatherapi.com/v1/forecast.json?q={city_query}&days=2&key={api_key}"
+    response = requests.get(url)
+    data = response.json()
+    if response.status_code == 200:
+        return data
+    else:
+        raise ValueError("API could not get info on given city query, or invalid API key.")
+
+
+def get_weather_category(condition_code,is_day):
+    weather_switch = {
+            "sun": [1000],
+            "partly cloudy": [1003],
+            "cloudy": [1006, 1009],
+            "fog": [1030, 1135, 1147],
+            "raining": [
+                1063, 1150, 1153, 1180, 1183, 1186, 1189, 1192, 1195, 1240,
+                1243, 1246, 1273, 1276
+                ],
+            "snowing": [
+                1066, 1114, 1117, 1168, 1171, 1204, 1207, 1210, 1213, 1216,
+                1219, 1222, 1225, 1255, 1258, 1279, 1282
+                ],
+            "thundering": [1087, 1273, 1276, 1279, 1282],
+            "windy": [1114, 1117]
+            }
+    if is_day == 0:
+        # If it is night , we change the category
+        weather_switch["moon"] = weather_switch.pop("sun", [1000])
+        weather_switch["partly cloudy night"] = weather_switch.pop("partly cloudy", [1003])
+
+    for category, codes in weather_switch.items():
+        if condition_code in codes:
+            return category
+    return "unknown"
+
+
+def get_weather_img(city_query:str, api_key, pixels:int=16) -> str:
+    # Get weather data
+    data_api = get_current_weather_data(city_query, api_key)
+
+    current_weather_code = data_api["current"]["condition"]["code"]
+    is_day = data_api["current"]["is_day"]
+
+    weather_category = get_weather_category(current_weather_code,is_day)
+    temperature_celsius = int(round(data_api["current"]["temp_c"])) 
+
+    # Do pixel img
+    img = Image.new('RGB', (pixels, pixels), color='black')
+    draw = ImageDraw.Draw(img)
+
+    # Extract the celsius digits
+    first_digit = str(temperature_celsius).zfill(2)[0]
+    second_digit = str(temperature_celsius).zfill(2)[1]
+
+    # Draw temperature and weather
+    draw_digit(draw, 3, 8, first_digit)
+    draw_digit(draw, 9, 8, second_digit)
+    draw_colored_pattern(draw, 4, 0, weather_category)
+
+    # Save the img
+    file_path = "weather.png"
+    img.save(file_path)
+
+    return file_path,
+
+
+def get_weather_gif(city_query:str, api_key:str, pixels:int=16) -> str:
+    data_api = get_current_weather_data_forecast(city_query, api_key=api_key)
+    current_hour = int(data_api["location"]["localtime"].split()[1].split(":")[0])
+
+    hourly_forecast = data_api["forecast"]["forecastday"][0]["hour"]
+    #Array for all the images
+    images=[]
+    #range must be max 6 because specs
+    for i in range(6):
+        #Checking if the next hour is in the same day or next
+        hour_index = (current_hour + i) % 24
+        if current_hour + i < 24:  # Same day
+            hour_data = data_api["forecast"]["forecastday"][0]["hour"][hour_index]
+        else:  # Next day
+            hour_data = data_api["forecast"]["forecastday"][1]["hour"][hour_index]
+
+        condition_code = hour_data["condition"]["code"]
+        is_day = hour_data["is_day"]
+
+        #Celsius temperature
+        temperature_celsius = int(round(hour_data["temp_c"]))
+
+        weather_category = get_weather_category(condition_code, is_day)
+
+        # Create the pixel image
+        img = Image.new('RGB', (pixels, pixels), color=1)
+        draw = ImageDraw.Draw(img)
+
+        # Extract the Celsius digits
+        first_digit = str(temperature_celsius).zfill(2)[0]
+        second_digit = str(temperature_celsius).zfill(2)[1]
+        # Determine the digit color (red for the first image, white for others)
+
+        draw.rectangle([0, 15, i, 15], fill=(255, 255, 255))  #horizontal line to draw the hour, each point is the index of the hour
+
+        draw_digit(draw, 3, 8, first_digit)
+        draw_digit(draw, 9, 8, second_digit)
+        draw_colored_pattern(draw, 4, 0, weather_category)
+
+        # Save the gif with a unique name
+        if img.getbbox():
+            images.append(img)
+        else:
+            print(f"IMG {i} is empty, it will not be added")
+
+    # Run the command with the new image
+
+    images_array = [numpy.array(img) for img in images]
+
+    gif_path = "weather_forecast.gif"
+
+    images[0].save(gif_path, save_all=True, append_images=images[1:], duration=[1000, 1000, 1000, 1000, 1000, 1000], loop=0)
+    return gif_path
+
+

--- a/windows_scripts/gui.ps1
+++ b/windows_scripts/gui.ps1
@@ -1,0 +1,4 @@
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+$root = Resolve-Path -Path "$PSScriptRoot\.."
+& "$root\run_in_venv.ps1" -DontInvokeApp "$root\gui.py"
+pause

--- a/windows_scripts/resize_and_combine_all.ps1
+++ b/windows_scripts/resize_and_combine_all.ps1
@@ -1,0 +1,129 @@
+# Image/gif resizer, gif-ifier, and merger.
+#
+# Requirements:
+#	Requires ImageMagick to be installed and on your path.
+#	How to install:
+#	- Get https://scoop.sh/
+#	- Run `scoop install imagemagick`
+#
+# Usage:
+# 	The script prompts you for inputs when you run it.
+# 	If you want to use the functions in your own scripts you can copy their lines directly.
+#
+# Other platforms (linux):
+#	This is a powershell script, but the imagemagick commands it will work on any platform with ImageMagick installed.
+#	Find the `magick` commands in the functions below, and copy them into your terminal, replacing the variables with your own values directly.
+#
+# What this does:
+# 	This script will convert every jpg+png+webp+gif+mp4 file in the input-folder to a gif of given pixel-size. 
+#	It then combines every gif in the output-folder into a single gif.
+#
+# 	If you want to merge your own gifs without converting anything, 
+#	you can put your gifs directly into the output folder of this script, so the script combines them. 
+#	If the folder doesn't exist you can run this script or make it manually. 
+#
+#	You don't need to put any images in your input folder for this.
+
+$outFolderName = "gif_output"
+$outGifName = "_combined"
+
+
+Function MassForceResize {
+	param (
+		[string]$InDirPath,
+		[string]$OutDirPath,
+		[string]$InFiletype,
+		[string]$OutFiletype,
+		[int]$PixelSize
+	  )
+	if (-not (Test-Path $OutDirPath)) {
+	  New-Item -Path $OutDirPath -ItemType Directory
+	}
+	Get-ChildItem "$InDirPath\" -Filter "*.$InFiletype" | 
+	Foreach-Object {
+		$base = $_.BaseName
+		$out  = "$OutDirPath\$base.$OutFiletype"
+
+		#____ The ImageMagick command ____#
+		#| If you're not on Windows, you can copy this line and input your own values, and it'll work on any platform that can use ImageMagick.
+		magick "$_.FullName" -resize "${PixelSize}x${PixelSize}^" -gravity center -extent "${PixelSize}x${PixelSize}" "$out"
+
+		Write-Output "Created file: $out"
+	}
+}
+
+
+
+Function MergeGifs {
+	param (
+	[string]$InDirPath,
+	[string]$OutFileName,
+	[float]$DelayInSeconds
+	)
+	$DelayInCentiSeconds = $DelayInSeconds*100
+	$inp = "$InDirPath\*.gif" 
+	$out = "$InDirPath\$OutFileName.gif"
+	if (Test-Path $out) {
+		Remove-Item $out
+	}
+
+	#____ The ImageMagick command ____#
+	#| If you're not on Windows, you can copy this line and input your own values, and it'll work on any platform that can use ImageMagick.
+	magick -delay $DelayInCentiSeconds $inp "$out"
+
+	Write-Output "Created file: $out"
+}
+
+
+
+
+$inPath = ""
+$answer = Read-Host "Enter path of folder to convert ('.' for current path)"
+if ($answer -eq '.') {
+	$inPath = $PSScriptRoot
+} else {
+	$inPath = $answer
+}
+$outPath = "$inPath\$outFolderName"
+Write-Host "Using input-folder path:  $inPath"
+Write-Host "Using output-folder path: $outPath"
+
+Write-Host "`n## INFORMATION ##"
+Write-Host "`n### What this does ###"
+Write-Host "This script will convert every jpg+png+webp image in the input-folder to a gif of given pixel-size. It then combines every gif in the output-folder `"$outFolderName`", into a single gif named `"$outGifName`"."
+Write-Host "`n### How to combine your own gifs ###"
+Write-Host "If you only want to merge gifs, you can put your gifs directly into the output folder of this script, so the script combines them. If the folder doesn't exist you can run this script or make it manually. You also don't need to put images in your input folder."
+
+
+Write-Host "`n## IMAGE CONVERTING ##"
+$targetsize = 0.0
+do {
+	$inp = Read-Host "Enter pixel size to make output gifs (e.g. 32 or 16)"
+	$inputValid = [int]::TryParse($inp, [ref]$targetsize)
+	if (-not $inputValid) {
+		Write-Host "Input wasn't an integer, try again: "
+	}
+} while (-not $inputValid)
+
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "jpg"  -OutFiletype "gif" -PixelSize $targetsize
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "png"  -OutFiletype "gif" -PixelSize $targetsize
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "webp" -OutFiletype "gif" -PixelSize $targetsize
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "gif"  -OutFiletype "gif" -PixelSize $targetsize
+MassForceResize -InDirPath $inPath -OutDirPath "$outPath" -InFiletype "mp4"  -OutFiletype "gif" -PixelSize $targetsize
+
+
+Write-Host "`n## IMAGE LOOPING ##"
+$secondsBetweenGifs = 0.0
+do {
+	$inp = Read-Host "Enter number of seconds delay between each image, use commas for floats"
+	$inputValid = [float]::TryParse($inp, [ref]$secondsBetweenGifs)
+	if (-not $inputValid) {
+		Write-Host "Input wasn't float, try again. You need to use commas for floats, e.g. '3,5'"
+	}
+} while (-not $inputValid)
+
+
+MergeGifs -InDirPath "$outPath" -OutFileName "_combined" -DelayInSeconds $secondsBetweenGifs
+
+
+Write-Host "Script complete"

--- a/windows_scripts/setup_and_make_launcher.ps1
+++ b/windows_scripts/setup_and_make_launcher.ps1
@@ -1,0 +1,74 @@
+# Starts by making sure the app is set up
+Write-Host "`n# SETTING UP iDotMatrix #"
+Write-Host "NOTE: If something goes wrong, try running the script with an administrator instance of Powershell."
+
+
+$root = Resolve-Path -Path "$PSScriptRoot\.."
+
+cd "$root"
+if (-not $?) {
+    Write-Host "\nERROR: Failed to navigate to root of repository"
+    pause
+    exit
+}
+
+
+Write-Host "`n## PYTHON SETUP ##"
+Write-Host "`n### VERIFYING LAUNCH DIRECTORY ###"
+Write-Host "INFO: Launching from $PSScriptRoot"
+Write-Host "INFO: Assuming $root is the root of the git repository."
+
+$GuiFileFound = Test-Path -Path ".\gui.py"
+if (-not $GuiFileFound) {
+    Write-Host "`nERROR: gui.py not found. `nThis means that the script wasn't launched from the correct folder.`n"
+    Write-Host "`nTo work correctly, you need to launch this script from the root folder of the iDotMatrix git folder."
+    Write-Host "`nTo do this, open the folder this script is located in in Windws Explorer, right click the script, and press 'Run in powershell'.`n"
+    Write-Host "`nIf that doesn't work, either open a powershell window and cd to the folder, or open the iDotMatrix git folder in Windows Explorer, then shift-right-click inside in an empty spot in the folder window, and click 'Open in powershell'."
+    Write-Host "`nWith powershell open, write .\windows_scripts\setup_and_make_launcher.ps1 and press enter"
+    pause
+    exit
+}
+
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
+$py_cmd = "$root/run_in_venv.ps1"
+
+Write-Host "`n### OPENING/MAKING VENV & INSTALLING DEPENDENCIES ###"
+& $py_cmd -DontInvokeApp -m pip install pyqt5 requests numpy
+
+
+Write-Host "`n## CREATING LAUNCHER SHORTCUT ##"
+Write-Host "This script will now create the shortcut on your desktop and in Windows list of programs."
+
+$WshShell = New-Object -COMObject WScript.Shell
+$ShortcutPath = "$Home\Desktop\iDotMatrix GUI.lnk"
+$Shortcut = $WshShell.CreateShortcut("$ShortcutPath")
+$Shortcut.TargetPath = "%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe"
+
+$userInput = Read-Host -Prompt "`nCHOICE: Do you want the terminal to be hidden when launching the GUI?`n[y/n]"
+if ($userInput -eq "y") {
+    $Shortcut.Arguments = "-WindowStyle Hidden -File `"$PSScriptRoot\gui.ps1`""
+    Write-Host "INFO: The launcher shortcut will now hide its terminal after opening. If the GUI isn't opening, re-run this script without hiding the terminal, so you can see what went wrong."
+} else {
+    $Shortcut.Arguments = "-File `"$PSScriptRoot\gui.ps1`""  #-WindowStyle Hidden 
+}
+
+$Shortcut.IconLocation = "$root\idmc.ico"
+$Shortcut.WorkingDirectory = split-path -parent $MyInvocation.MyCommand.Definition
+$Shortcut.Save()
+
+$ProgramsPath = "$env:USERPROFILE\AppData\Roaming\Microsoft\Windows\Start Menu\Programs"
+Write-Host "INFO: Copying shortcut to to $ProgramsPath"
+Copy-Item "$ShortcutPath" -Destination "$ProgramsPath"
+
+Write-Host "`n## FINISHED ##"
+
+Write-Host "`n### OPTIONAL TROUBLESHOOTING ###"
+Write-Host "- If something went wrong with the shortcut, try running the script with an administrator instance of Powershell, as Windows might require this for making the shortcut."
+Write-Host "- If some commands in the script fails, first re-run without a hidden terminal if you chose to hide it, to see the errors."
+Write-Host "- If that doesn't help, make sure you have Python installed, and see if you can open the GUI manually through powershell, by copying the commands in this file that start with `"python`"."
+Write-Host "`n### SUMMARY ###"
+Write-Host "A shortcut should now have been created on your desktop, and a copy of it added to $ProgramsPath to make the program searchable."
+Write-Host "Try opening it, if the shortcut isn't there or nothing shows up, read the TROUBLESHOOTING section above."
+Write-Host "`n`n"
+
+pause


### PR DESCRIPTION
This commit:
- Adds the reset command. This command saved my display from what seemed like a bugged state that restarting it didn't fix, where it didn't accept images and GIFs. I assume it's sort of like a factory reset, important to have. 
- Adds buttons for the GUI to send images and GIFs unprocessed, which allows you to send more things while getting errors. 
- Adds weather to the CLI - To do this, it extracts the code from the GUI, cleans it up and puts it into a module. Then it adds this to the CLI and then back to the GUI by calling the CLI. It also removes the need to hardcode your API key, and makes pixel size customizable. 
- In `gui.py`, changes from non-standard "py" to the universal "python". (I'll remove this from the other PR as well as the unprocessed buttons.)
- This also bumps the companion iDotPixel library version to the latest one, and adds weather requirements, now that they're included in the CLI.