### PR TITLE
Make run_in_venv create venv if needed & ensure the venv's python binary is used

### DIFF
--- a/run_in_venv.sh
+++ b/run_in_venv.sh
@@ -1,17 +1,36 @@
 #!/usr/bin/env bash
 set -e
-# get directory of file
-IDO_DIR="$(dirname "$0")"
-# activate venv
-if [[ "$OSTYPE" == "msys" ]]; then
-    # Windows Git Bash
-    source "$IDO_DIR/venv/Scripts/activate"
-else
-    # POSIX (Linux, macOS, etc.)
-    source "$IDO_DIR/venv/bin/activate"
-fi
 
-. "$IDO_DIR"/find_cmds.sh
+get_py() {
+    if command -v python3 &>/dev/null; then
+        echo "python3"
+        return 0
+    fi
+    if command -v python &>/dev/null; then
+        echo "python"
+        return 0
+    fi
+    echo "Python not found" >&2
+    return 1
+}
 
+get_venv_dir() {
+    local pwd_dir="$1"
+    if [[ "$OSTYPE" == "msys" ]]; then
+        # Windows Bash (msys, git bash)
+        echo "$pwd_dir/venv/Scripts"
+        return 0
+    else
+        # POSIX (Linux, macOS, etc.)
+        echo "$pwd_dir/venv/bin"
+        return 0
+    fi
+}
+
+
+pwd_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)  # POSIX-safe script directory fetching. Details: https://stackoverflow.com/a/29835459
+py_cmd=$(get_py)
+# open venv
+source "$venv_dir/activate"
 # run app
-$PYTHON_CMD "$IDO_DIR/app.py" "$@"
+$py_cmd "$pwd_dir/app.py" "$@"

--- a/run_in_venv.sh
+++ b/run_in_venv.sh
@@ -27,10 +27,25 @@ get_venv_dir() {
     fi
 }
 
+get_venv_py() {
+    # find and return a direct path to the python binary in the venv.
+    # this ensures we're not calling the global python binary,
+    # which can sometimes happen depending on the system.
+    local venv_dir="$1"
+    test -f "$venv_dir/python3" && echo "$venv_dir/python3" && return 0
+    test -f "$venv_dir/python"  && echo "$venv_dir/python"  && return 0
+    test -f "$venv_dir/py3"     && echo "$venv_dir/py3"     && return 0
+    test -f "$venv_dir/py"      && echo "$venv_dir/py"      && return 0
+    echo "Python not found in venv, was it correctly set up?" >&2
+    return 1
+}
+
 
 pwd_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)  # POSIX-safe script directory fetching. Details: https://stackoverflow.com/a/29835459
 py_cmd=$(get_py)
 # open venv
 source "$venv_dir/activate"
+# make sure we use the python binary belonging to the venv
+venv_py_cmd=$(get_venv_py "$venv_dir")
 # run app
-$py_cmd "$pwd_dir/app.py" "$@"
+$venv_py_cmd "$pwd_dir/app.py" "$@"

--- a/run_in_venv.sh
+++ b/run_in_venv.sh
@@ -27,6 +27,22 @@ get_venv_dir() {
     fi
 }
 
+setup_venv() {
+    local pwd_dir="$1"
+    local py_cmd=$(get_py)
+    # make venv
+    echo "Creating venv..."
+    $py_cmd -m venv "$pwd_dir/venv"
+    local venv_dir=$(get_venv_dir "$pwd_dir")
+    # open venv
+    source "$venv_dir/activate"
+    venv_py_cmd=$(get_venv_py "$venv_dir")
+    # install dependencies from pyproject.toml
+    echo "Installing dependencies into venv..."
+    $venv_py_cmd -m pip install "$pwd_dir/"
+    return 0
+}
+
 get_venv_py() {
     # find and return a direct path to the python binary in the venv.
     # this ensures we're not calling the global python binary,
@@ -43,6 +59,10 @@ get_venv_py() {
 
 pwd_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)  # POSIX-safe script directory fetching. Details: https://stackoverflow.com/a/29835459
 py_cmd=$(get_py)
+venv_dir=$(get_venv_dir "$pwd_dir")
+
+# create venv if it doesn't exist
+test -d "$venv_dir" || setup_venv "$pwd_dir"
 # open venv
 source "$venv_dir/activate"
 # make sure we use the python binary belonging to the venv

--- a/run_in_venv.sh
+++ b/run_in_venv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 # get directory of file
 IDO_DIR="$(dirname "$0")"


### PR DESCRIPTION
The venv is only created if the venv directory doesn't exist, so it has no impact on performance for regular usage. 
Depending on the system and Python version, calling the python command directly when inside the venv can fail to use the venv's python binary, instead using the global one. This issue has occurred for me a few times already, this update ensures the correct python binary is used.